### PR TITLE
Added an optional TItems for (I)ItemsHoldr

### DIFF
--- a/src/IItemsHoldr.ts
+++ b/src/IItemsHoldr.ts
@@ -26,16 +26,18 @@ export interface ITriggers {
 /**
  * Settings for item values, keyed by item key.
  */
-export interface IItemValues {
-    [i: string]: IItemSettings;
+export interface IItemValues<TItems> {
+    [i: string]: IItemSettings<TItems[any]>;
 }
 
 /**
  * Additional settings for storing an item.
+ *
+ * @type TItem  Type of the stored item.
  */
-export interface IItemSettings {
+export interface IItemSettings<TItem = any> {
     /**
-     * Maximum value the item may equal if a number.
+     * Maximum value the item may equal.
      */
     maximum?: number;
 
@@ -45,7 +47,7 @@ export interface IItemSettings {
     onMaximum?: IValueCallback<number>;
 
     /**
-     * Minimum value the item may equal if a number.
+     * Minimum value the item may equal.
      */
     minimum?: number;
 
@@ -55,7 +57,7 @@ export interface IItemSettings {
     onMinimum?: Function;
 
     /**
-     * Maximum number to modulo the value against if a number.
+     * Maximum number to modulo the value against.
      */
     modularity?: number;
 
@@ -73,20 +75,15 @@ export interface IItemSettings {
     /**
      * A default initial value to store, if value isn't provided.
      */
-    valueDefault?: any;
-}
-
-/**
- * Full export of stored items.
- */
-export interface IExportedItems {
-    [i: string]: string;
+    valueDefault?: TItem;
 }
 
 /**
  * Settings to initialize a new instance of the IItemsHoldr interface.
+ *
+ * @template TItems   Items names linked to their types.
  */
-export interface IItemsHoldrSettings {
+export interface IItemsHoldrSettings<TItems = any> {
     /**
      * Whether values should be saved immediately upon being set.
      */
@@ -95,7 +92,7 @@ export interface IItemsHoldrSettings {
     /**
      * Default attributes for item values.
      */
-    defaults?: IItemSettings;
+    defaults?: IItemSettings<TItems>;
 
     /**
      * Prefix to add before keys in storage.
@@ -110,13 +107,15 @@ export interface IItemsHoldrSettings {
     /**
      * Initial settings for item values to store.
      */
-    values?: IItemValues;
+    values?: IItemValues<TItems>;
 }
 
 /**
- * A versatile container to store and manipulate values in localStorage.
+ * Cache-based wrapper around localStorage.
+ *
+ * @template TItems   Items names linked to their types.
  */
-export interface IItemsHoldr {
+export interface IItemsHoldr<TItems = any> {
     /**
      * How many items are being stored.
      */
@@ -128,7 +127,7 @@ export interface IItemsHoldr {
      * @param index   An index for a key.
      * @returns The indexed key.
      */
-    key(index: number): string;
+    key(index: number): keyof TItems;
 
     /**
      * Gets whether autoSave is enabled.
@@ -147,71 +146,79 @@ export interface IItemsHoldr {
     /**
      * Creates a new item with settings.
      *
+     * @template TKey   Key name of an item.
      * @param key   Unique key to store the item under.
      * @param settings   Any additional settings for the item.
      */
-    addItem(key: string, settings?: IItemSettings): void;
+    addItem<TKey extends keyof TItems>(key: TKey, settings?: IItemSettings<TItems[TKey]>): void;
 
     /**
      * Gets a value under a key.
      *
+     * @template TKey   Key name of an item.
      * @param key   Key of an item.
      * @returns The known value of a key, assuming that key exists.
      */
-    getItem(key: string): any;
+    getItem<TKey extends keyof TItems>(key: TKey): TItems[TKey];
 
     /**
      * Clears a value from the listing.
      *
+     * @template TKey   Key name of an item.
      * @param key   The key of the value to remove.
      */
-    removeItem(key: string): void;
+    removeItem<TKey extends keyof TItems>(key: TKey): void;
 
     /**
      * Sets the value for an item under the given key.
      *
+     * @template TKey   Key name of an item.
      * @param key   Key of an item.
      * @param value   The new value for the item.
      */
-    setItem(key: string, value: any): void;
+    setItem<TKey extends keyof TItems>(key: TKey, value: TItems[TKey]): void;
 
     /**
      * Increases the value of an item as a number or string.
      *
+     * @template TKey   Key name of an item.
      * @param key   Key of an item.
      * @param amount   Amount to increase by (by default, 1).
      */
-    increase(key: string, amount?: number | string): void;
+    increase<TKey extends keyof TItems>(key: TKey, amount?: number | string): void;
 
     /**
      * Decreases the value of an item as a number.
      *
+     * @template TKey   Key name of an item.
      * @param key   Key of an item.
      * @param amount   Amount to increase by (by default, 1).
      */
-    decrease(key: string, amount?: number): void;
+    decrease<TKey extends keyof TItems>(key: TKey, amount?: number): void;
 
     /**
      * Toggles whether an item is true or false.
      *
+     * @template TKey   Key name of an item.
      * @param key   Key of an item.
      */
-    toggle(key: string): void;
+    toggle<TKey extends keyof TItems>(key: TKey): void;
 
     /**
      * Gets whether an item exists under the key.
      *
+     * @template TKey   Key name of an item.
      * @param key   The key for a potentially known value.
      * @returns Whether there is a value under that key.
      */
-    hasKey(key: string): boolean;
+    hasKey<TKey extends keyof TItems>(key: TKey): boolean;
 
     /**
      * Gets a summary of keys and their values.
      *
      * @returns A mapping of keys to their stored values.
      */
-    exportItems(): IExportedItems;
+    exportItems(): TItems;
 
     /**
      * Completely clears all items.
@@ -221,9 +228,10 @@ export interface IItemsHoldr {
     /**
      * Manually saves an item's value to storage, ignoring autoSave settings.
      *
+     * @template TKey   Key name of an item.
      * @param key   Key of an item to save.
      */
-    saveItem(key: string): void;
+    saveItem<TKey extends keyof TItems>(key: TKey): void;
 
     /**
      * Manually saves all items to storage, ignoring autoSave settings.

--- a/src/ItemContainer.ts
+++ b/src/ItemContainer.ts
@@ -4,7 +4,7 @@ import { proliferate } from "./proliferate";
 /**
  * Settings to initialize a new ItemContainer.
  */
-export interface IItemContainerSettings {
+export interface IItemContainerSettings<TItem = any> {
     /**
      * Whether this should save changes to localStorage automatically.
      */
@@ -13,7 +13,7 @@ export interface IItemContainerSettings {
     /**
      * Default attributes for items.
      */
-    defaults: IItemSettings;
+    defaults: IItemSettings<TItem>;
 
     /**
      * A prefix to store things under in localStorage.
@@ -29,7 +29,7 @@ export interface IItemContainerSettings {
 /**
  * Storage container for a single ItemsHoldr value.
  */
-export class ItemContainer {
+export class ItemContainer<TItem = any> {
     /**
      * Settings used for initialization.
      */
@@ -43,7 +43,7 @@ export class ItemContainer {
     /**
      * A default initial value to store, if value isn't provided.
      */
-    private readonly valueDefault: any;
+    private readonly valueDefault: TItem;
 
     /**
      * A mapping of values to callbacks that should be triggered when value
@@ -94,7 +94,7 @@ export class ItemContainer {
      * @param key   The key to reference this new ItemValue by.
      * @param item   Any custom settings for the value.
      */
-    public constructor(settings: IItemContainerSettings, key: string, item: IItemSettings = {}) {
+    public constructor(settings: IItemContainerSettings, key: string, item: IItemSettings<TItem> = {}) {
         this.settings = settings;
 
         proliferate(this, settings.defaults);


### PR DESCRIPTION
If provided, getting and setting items will adhere to an strongly typed interface (like the squee package).
This means type safety for those calls: no more `any`s!

Fixes #31.